### PR TITLE
Validate numeric query params strictly

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -66,12 +66,14 @@ const validTagsSet = new Set(tagsData);
 // Helper function to validate numeric parameter
 function validateNumericParam(value, paramName, min = null, max = null) {
   if (value === null || value === undefined) return null;
-  
-  const num = parseInt(value);
-  if (isNaN(num)) {
-    return { error: `${paramName} must be a valid number.` };
+
+  const valueStr = String(value).trim();
+  if (!/^\d+$/.test(valueStr)) {
+    return { error: `${paramName} must be a valid integer.` };
   }
-  
+
+  const num = parseInt(valueStr, 10);
+
   if (min !== null && num < min) {
     return { error: `${paramName} must be greater than or equal to ${min}.` };
   }

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -74,6 +74,9 @@ async function runTests() {
     const invalidCountResponse = await makeRequest('/api/quotes/random?count=0');
     test('Invalid count parameter rejected', invalidCountResponse.statusCode === 400);
 
+    const nonNumericCountResponse = await makeRequest('/api/quotes/random?count=5a');
+    test('Non-numeric count parameter rejected', nonNumericCountResponse.statusCode === 400);
+
     const negativeMinResponse = await makeRequest('/api/quotes/random?minLength=-50');
     test('Negative minLength rejected', negativeMinResponse.statusCode === 400);
 


### PR DESCRIPTION
## Summary
- ensure numeric query parameters are strict integers
- add tests for rejecting non-numeric count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a196525ccc832bb7148d259c9a332e