### PR TITLE
Use strict numeric parsing for query params

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -72,16 +72,19 @@ function validateNumericParam(value, paramName, min = null, max = null) {
     return { error: `${paramName} must be a valid integer.` };
   }
 
-  const num = parseInt(valueStr, 10);
+  const num = Number(valueStr);
+  if (Number.isNaN(num)) {
+    return { error: `${paramName} must be a valid integer.` };
+  }
 
   if (min !== null && num < min) {
     return { error: `${paramName} must be greater than or equal to ${min}.` };
   }
-  
+
   if (max !== null && num > max) {
     return { error: `${paramName} must be less than or equal to ${max}.` };
   }
-  
+
   return { value: num };
 }
 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -77,6 +77,12 @@ async function runTests() {
     const nonNumericCountResponse = await makeRequest('/api/quotes/random?count=5a');
     test('Non-numeric count parameter rejected', nonNumericCountResponse.statusCode === 400);
 
+    const alphaNumericCountResponse = await makeRequest('/api/quotes/random?count=10abc');
+    test('Alphanumeric count parameter rejected', alphaNumericCountResponse.statusCode === 400);
+
+    const exponentialCountResponse = await makeRequest('/api/quotes/random?count=5e2');
+    test('Exponential notation count parameter rejected', exponentialCountResponse.statusCode === 400);
+
     const negativeMinResponse = await makeRequest('/api/quotes/random?minLength=-50');
     test('Negative minLength rejected', negativeMinResponse.statusCode === 400);
 


### PR DESCRIPTION
## Summary
- Parse numeric query parameters with `Number` and regex to reject partial or scientific notation inputs
- Extend error handling tests for alphanumeric and exponential count values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a198807164832ba7fa33846a4001b3