### PR TITLE
Clarify count validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,11 +375,17 @@ Response format:
     }
     ```
     
--   Count validation:
-    
+-   Count validation: The API returns different messages depending on which bound is violated.
+
     ```json
     {
-      "error": "Count must be a number between 1 and 50."
+      "error": "count must be greater than or equal to 1."
+    }
+    ```
+
+    ```json
+    {
+      "error": "count must be less than or equal to 50."
     }
     ```
 


### PR DESCRIPTION
## Summary
- Document distinct count validation errors for lower and upper bounds in the README
- Note that the API returns different messages depending on the violated bound

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a198811c94832bbc85ae803a5fd735