### PR TITLE
Add malformed count parameter test and clarify numeric validation error

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -69,7 +69,7 @@ function validateNumericParam(value, paramName, min = null, max = null) {
 
   const valueStr = String(value).trim();
   if (!/^\d+$/.test(valueStr)) {
-    return { error: `${paramName} must be a valid integer.` };
+    return { error: `${paramName} must be a valid number.` };
   }
 
   const num = parseInt(valueStr, 10);

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -80,6 +80,13 @@ async function runTests() {
     const negativeMinResponse = await makeRequest('/api/quotes/random?minLength=-50');
     test('Negative minLength rejected', negativeMinResponse.statusCode === 400);
 
+    const malformedCountResponse = await makeRequest('/api/quotes/random?count=10abc');
+    test(
+      'Malformed count parameter rejected with valid number error',
+      malformedCountResponse.statusCode === 400 &&
+        malformedCountResponse.body.includes('valid number')
+    );
+
     const invalidMethodResponse = await makeRequest('/api/quotes/random', 'POST');
     test('Invalid HTTP method returns 405', invalidMethodResponse.statusCode === 405);
 


### PR DESCRIPTION
## Summary
- test API error handling with malformed `count` value
- make numeric validation report "valid number"

## Testing
- `npm test` (fails before fix)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a198817294832b9d2660cfdc429e1f