### PR TITLE
feat: make rate limiting configurable and expand tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Response format:
 -   **Scope**: Per IP address
 -   **Headers**: Standard rate limit headers included in responses
 -   **Recovery**: Limits reset automatically after the 15-minute window
+-   **Configuration**: Set `ENABLE_RATE_LIMIT=false` to disable rate limiting (useful for testing). Unset or `true` keeps it enabled.
 -   **Important:** Exceeding the rate limit will result in a `429 Too Many Requests` error. To avoid this, utilize the `count` parameter to fetch multiple quotes in a single request and cache the results locally. If you require high-volume access, please fork the repository and deploy your own instance.
 
 ## Technical Details
@@ -433,15 +434,13 @@ QuoteSlate includes a comprehensive test suite to ensure API reliability and sec
 
 ### Running Tests
 
-1. **Start the server:**
-   ```bash
-   npm start
-   ```
+Run the test suite directly:
 
-2. **Run tests (in a separate terminal):**
-   ```bash
-   npm test
-   ```
+```bash
+npm test
+```
+
+The tests automatically start a server instance with rate limiting disabled, execute all checks, and then verify rate limiting behavior with the limiter enabled.
 
 ### Test Coverage
 

--- a/src/api.js
+++ b/src/api.js
@@ -26,18 +26,21 @@ app.use((req, res, next) => {
 });
 
 // Configure rate limiting for abuse protection
-const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15-minute window
-  max: 100, // Maximum requests per IP for the time window
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: {
-    error: "Too many requests, please try again later.",
-  },
-});
+const enableRateLimit = process.env.ENABLE_RATE_LIMIT !== "false";
+if (enableRateLimit) {
+  const apiLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15-minute window
+    max: 100, // Maximum requests per IP for the time window
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      error: "Too many requests, please try again later.",
+    },
+  });
 
-// Enforce rate limits on API routes
-app.use("/api/", apiLimiter);
+  // Enforce rate limits on API routes
+  app.use("/api/", apiLimiter);
+}
 
 // Load quote data at startup
 const quotesData = JSON.parse(

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 const http = require('http');
-
-const BASE_URL = 'http://localhost:3000';
+const { spawn } = require('child_process');
 
 function makeRequest(path, method = 'GET') {
   return new Promise((resolve, reject) => {
@@ -10,7 +9,7 @@ function makeRequest(path, method = 'GET') {
       hostname: 'localhost',
       port: 3000,
       path: path,
-      method: method
+      method: method,
     };
 
     const req = http.request(options, (res) => {
@@ -22,7 +21,7 @@ function makeRequest(path, method = 'GET') {
         resolve({
           statusCode: res.statusCode,
           headers: res.headers,
-          body: body
+          body: body,
         });
       });
     });
@@ -33,6 +32,110 @@ function makeRequest(path, method = 'GET') {
 
     req.end();
   });
+}
+
+function startServer(extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', ['src/index.js'], {
+      env: { ...process.env, ...extraEnv },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stdout.on('data', (data) => {
+      const text = data.toString();
+      if (text.includes('Quotes API listening')) {
+        resolve(child);
+      }
+    });
+
+    child.stderr.on('data', (data) => {
+      console.error(data.toString());
+    });
+
+    child.on('error', reject);
+  });
+}
+
+function stopServer(child) {
+  return new Promise((resolve) => {
+    child.on('close', resolve);
+    child.kill();
+  });
+}
+
+async function runBasicTests(test) {
+  console.log('Testing basic functionality:');
+  const randomQuoteResponse = await makeRequest('/api/quotes/random');
+  test('Random quote endpoint returns 200', randomQuoteResponse.statusCode === 200);
+
+  const quote = JSON.parse(randomQuoteResponse.body);
+  test('Random quote has required fields', quote.id && quote.quote && quote.author && quote.length && quote.tags);
+
+  const authorsResponse = await makeRequest('/api/authors');
+  test('Authors endpoint returns 200', authorsResponse.statusCode === 200);
+
+  const tagsResponse = await makeRequest('/api/tags');
+  test('Tags endpoint returns 200', tagsResponse.statusCode === 200);
+
+  console.log();
+  console.log('Testing error handling:');
+
+  const invalidCountResponse = await makeRequest('/api/quotes/random?count=0');
+  test('Invalid count parameter rejected', invalidCountResponse.statusCode === 400);
+
+  const nonNumericCountResponse = await makeRequest('/api/quotes/random?count=5a');
+  test('Non-numeric count parameter rejected', nonNumericCountResponse.statusCode === 400);
+
+  const alphaNumericCountResponse = await makeRequest('/api/quotes/random?count=10abc');
+  test('Alphanumeric count parameter rejected', alphaNumericCountResponse.statusCode === 400);
+
+  const exponentialCountResponse = await makeRequest('/api/quotes/random?count=5e2');
+  test('Exponential notation count parameter rejected', exponentialCountResponse.statusCode === 400);
+
+  const negativeMinResponse = await makeRequest('/api/quotes/random?minLength=-50');
+  test('Negative minLength rejected', negativeMinResponse.statusCode === 400);
+
+  const malformedCountResponse = await makeRequest('/api/quotes/random?count=10abc');
+  test(
+    'Malformed count parameter rejected with valid number error',
+    malformedCountResponse.statusCode === 400 &&
+      malformedCountResponse.body.includes('valid number')
+  );
+
+  const invalidMethodResponse = await makeRequest('/api/quotes/random', 'POST');
+  test('Invalid HTTP method returns 405', invalidMethodResponse.statusCode === 405);
+
+  const invalidPathResponse = await makeRequest('/api/quotes/invalid');
+  test('Invalid API path returns 404', invalidPathResponse.statusCode === 404);
+
+  console.log();
+  console.log('Testing security headers:');
+  test('X-Content-Type-Options header present', randomQuoteResponse.headers['x-content-type-options'] === 'nosniff');
+  test('X-Frame-Options header present', randomQuoteResponse.headers['x-frame-options'] === 'DENY');
+  test('X-XSS-Protection header present', randomQuoteResponse.headers['x-xss-protection'] === '1; mode=block');
+
+  console.log();
+}
+
+async function testRateLimitDisabled(test) {
+  const responses = [];
+  for (let i = 0; i < 101; i++) {
+    responses.push(await makeRequest('/api/quotes/random'));
+  }
+  const has429 = responses.some((r) => r.statusCode === 429);
+  test('No rate limiting when ENABLE_RATE_LIMIT=false', !has429);
+}
+
+async function testRateLimitEnabled(test) {
+  let rateLimited = false;
+  for (let i = 0; i < 101; i++) {
+    const res = await makeRequest('/api/quotes/random');
+    if (res.statusCode === 429) {
+      rateLimited = true;
+      break;
+    }
+  }
+  test('Rate limiting enforced when ENABLE_RATE_LIMIT=true', rateLimited);
 }
 
 async function runTests() {
@@ -51,88 +154,42 @@ async function runTests() {
     }
   }
 
+  let server;
   try {
-    // Verify core endpoints behave as expected
-    console.log('Testing basic functionality:');
-    const randomQuoteResponse = await makeRequest('/api/quotes/random');
-    test('Random quote endpoint returns 200', randomQuoteResponse.statusCode === 200);
-    
-    const quote = JSON.parse(randomQuoteResponse.body);
-    test('Random quote has required fields', quote.id && quote.quote && quote.author && quote.length && quote.tags);
-
-    const authorsResponse = await makeRequest('/api/authors');
-    test('Authors endpoint returns 200', authorsResponse.statusCode === 200);
-
-    const tagsResponse = await makeRequest('/api/tags');
-    test('Tags endpoint returns 200', tagsResponse.statusCode === 200);
-
-    console.log();
-
-    // Verify error responses for invalid requests
-    console.log('Testing error handling:');
-    
-    const invalidCountResponse = await makeRequest('/api/quotes/random?count=0');
-    test('Invalid count parameter rejected', invalidCountResponse.statusCode === 400);
-
-    const nonNumericCountResponse = await makeRequest('/api/quotes/random?count=5a');
-    test('Non-numeric count parameter rejected', nonNumericCountResponse.statusCode === 400);
-
-    const alphaNumericCountResponse = await makeRequest('/api/quotes/random?count=10abc');
-    test('Alphanumeric count parameter rejected', alphaNumericCountResponse.statusCode === 400);
-
-    const exponentialCountResponse = await makeRequest('/api/quotes/random?count=5e2');
-    test('Exponential notation count parameter rejected', exponentialCountResponse.statusCode === 400);
-
-    const negativeMinResponse = await makeRequest('/api/quotes/random?minLength=-50');
-    test('Negative minLength rejected', negativeMinResponse.statusCode === 400);
-
-    const malformedCountResponse = await makeRequest('/api/quotes/random?count=10abc');
-    test(
-      'Malformed count parameter rejected with valid number error',
-      malformedCountResponse.statusCode === 400 &&
-        malformedCountResponse.body.includes('valid number')
-    );
-
-    const invalidMethodResponse = await makeRequest('/api/quotes/random', 'POST');
-    test('Invalid HTTP method returns 405', invalidMethodResponse.statusCode === 405);
-
-    const invalidPathResponse = await makeRequest('/api/quotes/invalid');
-    test('Invalid API path returns 404', invalidPathResponse.statusCode === 404);
-
-    console.log();
-
-    // Confirm security headers are present
-    console.log('Testing security headers:');
-    test('X-Content-Type-Options header present', randomQuoteResponse.headers['x-content-type-options'] === 'nosniff');
-    test('X-Frame-Options header present', randomQuoteResponse.headers['x-frame-options'] === 'DENY');
-    test('X-XSS-Protection header present', randomQuoteResponse.headers['x-xss-protection'] === '1; mode=block');
-
-    console.log();
-
-    // Display a summary of test results
-    console.log('=== Test Summary ===');
-    console.log(`${testsPassed}/${totalTests} tests passed`);
-    
-    if (testsPassed === totalTests) {
-      console.log('🎉 All tests passed!');
-      process.exit(0);
-    } else {
-      console.log('❌ Some tests failed.');
-      process.exit(1);
+    // Run tests with rate limiting disabled
+    server = await startServer({ ENABLE_RATE_LIMIT: 'false' });
+    await runBasicTests(test);
+    await testRateLimitDisabled(test);
+  } finally {
+    if (server) {
+      await stopServer(server);
     }
+  }
 
-  } catch (error) {
-    console.error('Error running tests:', error);
+  try {
+    // Run rate limit check with limiter enabled
+    server = await startServer({ ENABLE_RATE_LIMIT: 'true' });
+    await testRateLimitEnabled(test);
+  } finally {
+    if (server) {
+      await stopServer(server);
+    }
+  }
+
+  console.log();
+  console.log('=== Test Summary ===');
+  console.log(`${testsPassed}/${totalTests} tests passed`);
+
+  if (testsPassed === totalTests) {
+    console.log('🎉 All tests passed!');
+    process.exit(0);
+  } else {
+    console.log('❌ Some tests failed.');
     process.exit(1);
   }
 }
 
-// Ensure the server is running before executing tests
-makeRequest('/api/quotes/random')
-  .then(() => {
-    runTests();
-  })
-  .catch(() => {
-    console.error('❌ Server is not running. Please start the server with "npm start" before running tests.');
-    process.exit(1);
-  });
+runTests().catch((error) => {
+  console.error('Error running tests:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- allow disabling rate limiting via `ENABLE_RATE_LIMIT` env var
- rewrite test suite to start servers automatically and verify rate limit behavior
- document rate limit configuration and updated testing instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a2d4f2c2e4832ba0ba1929dc7f79cf