### PR TITLE
chore: update express-rate-limit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "express": "^5.1.0",
     "cors": "^2.8.5",
-    "express-rate-limit": "^8.0.0"
+    "express-rate-limit": "^8.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- update express-rate-limit to latest stable 8.0.1
- verify express and cors dependencies are current

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a2d98165e0832b8054ff400075e3f3