### PR TITLE
docs: add Vercel deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A robust, developer-friendly API for serving inspirational and thought-provoking
 
 [Explore the API](https://quoteslate.vercel.app) | [Documentation](https://github.com/Musheer360/QuoteSlate#api-reference) | [Deploy Your Own](https://github.com/Musheer360/QuoteSlate#deploying-on-vercel-easiest-for-high-volume-needs)
 
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/Musheer360/QuoteSlate)
+
 </div>
 
 ## 📚 Table of Contents

--- a/public/index.html
+++ b/public/index.html
@@ -243,6 +243,7 @@
         <header>
             <h1>QuoteSlate API</h1>
             <p class="subtitle">Discover inspiring quotes with ease.</p>
+            <a href="https://vercel.com/new/clone?repository-url=https://github.com/Musheer360/QuoteSlate" target="_blank"><img src="https://vercel.com/button" alt="Deploy with Vercel" /></a>
         </header>
 
         <div class="container">


### PR DESCRIPTION
## Summary
- add "Deploy with Vercel" button to README for one-click deployments
- include Vercel deploy button on the API landing page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a2ec39e1fc832bb1562cc000afc5ab